### PR TITLE
Add embedded prom server to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
+FROM prom/prometheus as prom
+COPY tools/docker/prometheus_embedded.yml /etc/prometheus/prometheus.yml
+
 # Build image
 FROM golang:1.20-buster as buildgo
 RUN go version
-WORKDIR /working
+WORKDIR /usr/local/myapp
 
+
+RUN apt-get -y update; apt-get -y install curl iproute2 lsof
 COPY Makefile  ./
-
+COPY tools/docker/run.sh ./
 ADD go.mod go.sum ./
 RUN go mod download
 
@@ -18,15 +23,36 @@ COPY plugin plugin
 # Build the golang binary
 RUN make all
 
+# hacking... goal: prom running in the same container as my app
+COPY --from=prom /prometheus /prometheus
+COPY --from=prom /bin/prometheus /bin/prometheus
+COPY --from=prom /bin/promtool /bin/promtool
+COPY --from=prom /etc/prometheus/prometheus.yml /etc/prometheus/prometheus.yml
+
+
+#RUN apt-get -y update; apt-get -y install curl iproute2 lsof
+#WORKDIR /usr/local/myapp
+#COPY --from=buildgo /workdir /usr/local/myapp/
+
+#FROM ubuntu:20.04
+#WORKDIR /usr/local/myapp
+#RUN apt-get -y update; apt-get -y install curl
+
+#COPY --from=buildgo /workdir /usr/local/myapp/
+
+
+
 # prom metrics endpoints
 EXPOSE 2112
 # plugin range
 EXPOSE 2113-2200
+EXPOSE 9192
+EXPOSE 9090
 
-RUN mkdir -p /etc/prometheus/targets
 
-ENTRYPOINT ["bin/cli"]
+
+#ENTRYPOINT ["bin/cli"]
 
 #HEALTHCHECK CMD curl -f http://localhost:6688/health || exit 1
 
-CMD ["server", "start"]
+CMD ["/bin/bash", "-c", "./run.sh"]

--- a/common/port_scanner.go
+++ b/common/port_scanner.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+func GetPortInRange(start, end int) (int, error) {
+	if start > end {
+		return -1, fmt.Errorf("bad input range")
+	}
+	for i := start; i < end; i++ {
+		ok := freePort(i)
+		if ok {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("no open port in %d-%d", start, end)
+}
+
+// true if port is not in use
+func freePort(port int) bool {
+	address := ":" + strconv.Itoa(port)
+	conn, err := net.DialTimeout("tcp", address, 10*time.Millisecond)
+
+	if err != nil {
+		return errors.Is(err, syscall.ECONNREFUSED)
+	}
+	defer conn.Close()
+	return true
+}

--- a/plugin/greeter.go
+++ b/plugin/greeter.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -48,6 +50,10 @@ var handshakeConfig = plugin.HandshakeConfig{
 }
 
 func main() {
+	// the host process assigns a port to use. reconsider this choice in fully model
+	portArg := flag.Int("port", 2200, "port for prometheus server")
+	flag.Parse()
+
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level:      hclog.Trace,
 		Output:     os.Stderr,
@@ -67,9 +73,10 @@ func main() {
 	}()
 
 	go func() {
+		logger.Info("starting metric server on", "port", *portArg)
 		http.Handle("/metrics", promhttp.Handler())
-
-		err := http.ListenAndServe(":2113", nil)
+		addr := fmt.Sprintf(":%d", *portArg)
+		err := http.ListenAndServe(addr, nil)
 		if err != nil {
 			log.Fatalf("error starting prom metric endpoint: %v", err)
 		}

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     # Note that the keystore import allows us to submit transactions
     # immediately because addresses are specified when starting the
     # parity/geth node to be prefunded with eth.
-    entrypoint: /bin/sh -c "bin/cli server start"
+    entrypoint: /bin/sh -c "/usr/local/myapp/run.sh"
     restart: always
     ports:
       # grpc server

--- a/tools/docker/prometheus_embedded.yml
+++ b/tools/docker/prometheus_embedded.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 10s
+
+scrape_configs:
+  - job_name: host
+    static_configs:
+      - targets: ["localhost:2112"]
+ # - job_name: 'file-based-targets'
+ #   file_sd_configs:
+ #   - files:
+ #     - '/etc/prometheus/targets/*.json'
+  - job_name: 'plugin-targets'
+    http_sd_configs:
+      - url: "http://localhost:2112/sd_config"
+        refresh_interval: 10s

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+echo "hi"
+
+prometheus --web.listen-address="0.0.0.0:9192" --config.file=/etc/prometheus/prometheus.yml &
+
+bin/cli server start &
+echo "done starting server"
+sleep 2
+bin/cli plugin --name abc start
+
+sleep 100000000


### PR DESCRIPTION
Adds prom directly to the Dockerfile for my app.

This enables container to expose two ports, one for the app and one for the prom server

But managing the prom dep is very hacky right now and unclear how that would be made better.

Service disco + many open ports feels nicer ATM