### PR TITLE
Dynamic HTTP routing to plugin metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
 # go-plugin-prom
+
+
+# Demoware for integrating hashicorp plugins and prometheus
+
+## Quickstart
+```
+sh
+cd tools/docker
+docker compose build
+docker compose up
+```
+
+go to `localhost:9091` to see the prom instance
+
+Navigate to targets: `http://localhost:9091/targets`
+
+After ~ 1 minute you should see a plugin endpoint like
+```
+http://host.docker.internal:2112/plugins/abc/metrics	UP	
+instance="host.docker.internal:2112"job="plugin_abc-wrapper"
+4.599s ago	
+26.599ms
+```
+
+(Ignore the `http://localhost` endpoint that are `DOWN`; this is quirk to be worked out wrt docker networking)
+
+Once the plugin endpoint is up, run a query for plugin specific metrics:
+`http://localhost:9091/graph`
+search for `plugin_greet_count`, or `plugin_ticker_count`
+
+
+### Under the hood
+The `docker compose up` does
+1. runs a grpc server
+2. causes the grpc to start a plugin named `abc`
+3. runs prometheus in a another container. this prom instance is configured to monitor the grpc service and the service discovery endpoint it exposes
+# Details
+
+This package implements a GRPC server that starts and stops a plugin.
+
+The interesting bit with regard to prometheus is that we use service discovery and dynamic HTTP routing to
+hide the plugins behind the GRPC server.
+
+The plugin itself is running prom handler and a web server, but that web server in not exposed outside the container.
+This enables the fully power of prom metrics in a plugin limiting the exposed ports.
+
+Leveraging service discovery and HTTP routing enables us to totally seperate metric monitoring from plugin application
+logic.
+
+In order for the plugin to be monitored by prom, we implement 2 HTTP endpoints in the GRPC server in addition to it's own prom `/metrics` endpoint
+
+The endpoints serve to 
+1. enable external prometheus prom to do dynamically determine what to monitor based on what plugins are running 
+2. route external prom scraping to the plugins without exposing them directly
+
+Specifically the endpoints are 
+- `/sd_config` : HTTP Service Discovery [https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config]
+    - prom is configured to poll this url to discover new endpoints to monitor. The grpc service serves the response based on what plugins are running
+    - the endpoints are like `plugins/<name>/metrics` and do not directly expose a port on the plugin
+- `/plugins/<name>/metrics`: Middleware to route from service discover to plugin `/metrics` endpoint
+    - Once a service is discovered as above, prom calls the target endpoint at the scrape interval
+    - The GRPC service acts as middleware to route the request to the `/metrics` endpoint of the requested plugin
+
+

--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,18 @@ require github.com/hashicorp/go-hclog v1.5.0
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -44,6 +45,7 @@ github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.15.0 h1:5fCgGYogn0hFdhyhLbw7hEsWxufKtY9klyvdNfFlFhM=
 github.com/prometheus/client_golang v1.15.0/go.mod h1:e9yaBhRPU2pPNsZwE+JdQl0KEt1N9XgF6zxWmaC0xOk=
@@ -59,11 +61,14 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/urfave/cli v1.22.12 h1:igJgVw1JdKH+trcLWLeLwZjU9fEfPesQ+9/e4MQ44S8=
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
 github.com/urfave/cli/v2 v2.25.1 h1:zw8dSP7ghX0Gmm8vugrs6q9Ku0wzweqPyshy+syu9Gw=
@@ -99,4 +104,5 @@ google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/plugin/greeter.go
+++ b/plugin/greeter.go
@@ -18,12 +18,12 @@ import (
 
 var (
 	greet_count = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "greet_count",
+		Name: "plugin_greet_count",
 		Help: "The total number of starts events",
 	})
 
 	ticker_count = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "ticker_count",
+		Name: "plugin_ticker_count",
 		Help: "Ticker every 10s seconds",
 	})
 )

--- a/server/host.go
+++ b/server/host.go
@@ -20,11 +20,13 @@ import (
 type pluginWrapper struct {
 	*plugin.Client
 	promTarget *targetgroup.Group
+	port       int
+	name       string
 }
 
 func startPlugin(name string) (*pluginWrapper, error) {
 	logger := hclog.New(&hclog.LoggerOptions{
-		Name:   "plugin",
+		Name:   fmt.Sprintf("plugin-%s", name),
 		Output: os.Stdout,
 		Level:  hclog.Debug,
 	})
@@ -38,10 +40,11 @@ func startPlugin(name string) (*pluginWrapper, error) {
 	target := &targetgroup.Group{
 		Targets: []model.LabelSet{
 			{model.AddressLabel: model.LabelValue(fmt.Sprintf("localhost:%d", port))},
-			{model.AddressLabel: model.LabelValue(fmt.Sprintf("host.docker.internal:%d", port))},
+			//	{model.AddressLabel: model.LabelValue(fmt.Sprintf("host.docker.internal:%d", port))},
 		},
 		Labels: map[model.LabelName]model.LabelValue{
 			"job": model.LabelValue(fmt.Sprintf("plugin_%s", name)),
+			//model.MetricsPathLabel: model.LabelValue("custom_metric_path"),
 		},
 		Source: "",
 	}
@@ -76,6 +79,8 @@ func startPlugin(name string) (*pluginWrapper, error) {
 	return &pluginWrapper{
 		Client:     client,
 		promTarget: target,
+		port:       port,
+		name:       name,
 	}, nil
 }
 

--- a/server/operator_test.go
+++ b/server/operator_test.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractPluginName(t *testing.T) {
+
+	want := "myname"
+	input := "/plugins/myname/metrics"
+	got := extractPluginName(input)
+	assert.Equal(t, got, want)
+}

--- a/tools/docker/prometheus.yml
+++ b/tools/docker/prometheus.yml
@@ -5,10 +5,6 @@ scrape_configs:
   - job_name: host
     static_configs:
       - targets: ["host.docker.internal:2112"]
- # - job_name: 'file-based-targets'
- #   file_sd_configs:
- #   - files:
- #     - '/etc/prometheus/targets/*.json'
   - job_name: 'plugin-targets'
     http_sd_configs:
       - url: "http://host.docker.internal:2112/sd_config"


### PR DESCRIPTION
Adds a new HTTP endpoint in the grpc server
`/plugins/`

and a handler that routes `/plugins/<name>/metrics` to the running plugin's `/metrics` endpoint

Changes the service discovery mechanism so that the targets are behind this new `plugins` endpoint.

When a new plugin is started, the SD will now report a target like

`<grpc_server_port>/plugins/<name>/metrics`

instead of directly exposing ports on the plugin itself